### PR TITLE
fix macos build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn build_lerc() {
     let mut build = cc::Build::new();
     build
         .cpp(true)
+        .std("c++17")
         .include(format!("{base}/include"))
         .include(base);
 


### PR DESCRIPTION
Macos build is currently broken since apple clang defaults to C++98. This pr fixes the issue by explicitly setting the standard version to C++17. C++17 was chosen since Esri's Linux build config (found [here](https://github.com/Esri/lerc/blob/master/build/linux/CodeBlocks/Lerc/Lerc_so.cbp#L43)) uses C++17. 