### PR TITLE
fix linking on macos

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,8 +23,6 @@ fn build_lerc() {
 
     build.compile("lerc");
 
-    println!("cargo:rustc-link-lib=stdc++");
-    println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed={base}");
 }
 


### PR DESCRIPTION
I missed this the first time around because for some reason it only breaks when actually building an application binary, and not when building it as a library. `stdc++` is the gnu stdlib so it is not available on macos. However, cc-rs should automatically link to the correct stdlib for the target platform, so it shouldn't be necessary to have a cargo instruction. The linked stdlib will still be `stdc++` on Linux. 

I also removed the cargo instruction to rerun if build.rs is changed, since cargo should rerun the build script if build.rs is changed no matter what, so the instruction is unnecessary. 